### PR TITLE
makes vif.gam works when a predictor is a Boolean variable and adds a…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,4 @@ Imports: dplyr,
     magrittr,
     tibble,
     stats
+Suggests: testthat

--- a/R/vif.gam.R
+++ b/R/vif.gam.R
@@ -47,7 +47,9 @@ vif.gam <- function(object){
   n <- nrow(X) # how many observations were used in fitting?
   v <- -1 # omit the intercept term, it can't inflate variance
   varbeta <- obj.sum$p.table[v,2]^2 # variance in estimates
-  varXj <- apply(X=X[,row.names(obj.sum$p.table)[v]],MARGIN=2, var) # variance of all the explanatory variables
+  selected_col <- row.names(obj.sum$p.table)[v]
+  selected_col <- gsub("TRUE", "", selected_col)
+  varXj <- apply(X=X[, selected_col],MARGIN=2, var) # variance of all the explanatory variables
   VIF <- varbeta/(s2/(n-1)*1/varXj) # the variance inflation factor, obtained by rearranging
   # var(beta_j) = s^2/(n-1) * 1/var(X_j) * VIF_j
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(mgcv.helper)
+
+test_check("mgcv.helper")

--- a/tests/testthat/test-vif-gam.R
+++ b/tests/testthat/test-vif-gam.R
@@ -1,0 +1,45 @@
+context("vif.gam")
+
+testthat::test_that("vif.gam works for an example", {
+  library("dplyr")
+
+  set.seed(101)
+  N <- 100
+  x1 <- runif(n=N)
+  x2 <- runif(n=N)
+  x3 <- runif(n=N) + 0.9*x1 - 1.75*x2
+
+  df <- data.frame(x1 = x1,
+                   x2 = x2,
+                   x3 = x3) %>%
+    mutate(y = rnorm(n=N,
+                     mean = 1 - 2*x1 + 3*x2 - 0.5*x3,
+                     sd = 0.5))
+
+  fit1 <- mgcv::gam(data=df, y ~ x1 + x2 + x3)
+
+
+  expect_is(vif.gam(fit1), "tbl_df")
+})
+
+testthat::test_that("vif.gam works for an example with a Boolean variable", {
+  library("dplyr")
+
+  set.seed(101)
+  N <- 100
+  x1 <- runif(n=N)
+  x2 <- runif(n=N)>0.5
+  x3 <- runif(n=N) + 0.9*x1 - 1.75*x2
+
+  df <- data.frame(x1 = x1,
+                   x2 = x2,
+                   x3 = x3) %>%
+    mutate(y = rnorm(n=N,
+                     mean = 1 - 2*x1 - 0.5*x3,
+                     sd = 0.5))
+
+  fit1 <- mgcv::gam(data=df, y ~ x1 + x2 + x3)
+
+
+  expect_is(vif.gam(fit1), "tbl_df")
+})


### PR DESCRIPTION
… test for that.

before that the function returned an error message for Boolean variables. The reason for that is that the name of the variable in the summary is originalnameTRUE, so the column selection didn't work.

Nice package by the way!